### PR TITLE
Add more fixes and support older python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,9 +18,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
+      max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package consists of base classes to build interfaces and a mock
 device used for testing and as an example of implementation.
 
 Device connection such as `serial` and parsers such as `json` are used to get
-standard output
+standard output.
 
 ## Concept
 
@@ -76,6 +76,9 @@ _Note: setuptools package should be installed._
 
 This package is meant to be built upon. An example implementation is done with
 the [mock_if](mock_pal/mock_if.py) and the [mock_cli](mock_pal/mock_cli.py).
+
+The mm_cmd is based on the [cmd2](https://github.com/python-cmd2/cmd2) module
+is probably worth reading the [documenation](https://cmd2.readthedocs.io/en/latest/).
 
 ## Useful commands
 

--- a/mm_pal/__init__.py
+++ b/mm_pal/__init__.py
@@ -13,7 +13,7 @@ from .misc import serial_connect_wizard
 
 __author__ = "Kevin Weiss"
 __email__ = "kevin.weiss@gmail.com"
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 __all__ = ['MmIf',
            'MmCmd',

--- a/mm_pal/mm_cmd.py
+++ b/mm_pal/mm_cmd.py
@@ -121,15 +121,6 @@ class MmCmd(Cmd):
                                   retry=opts.retry)
         self.poutput("Success")
 
-    read_struct_parser = argparse.ArgumentParser()
-    read_struct_parser.add_argument('struct',
-                                    choices_method=regs_choices_method,
-                                    help="Name of the struct to read")
-    read_struct_parser.add_argument('--data-without-names', '-d',
-                                    action="store_false",
-                                    help="Show only the data without reg name")
-    add_timeout_retry_arguments(read_struct_parser)
-
     commit_write_parser = argparse.ArgumentParser()
     commit_write_parser.add_argument('reg', choices_method=regs_choices_method,
                                      help="name of the register to read")
@@ -155,18 +146,22 @@ class MmCmd(Cmd):
     read_struct_parser.add_argument('struct',
                                     choices_method=regs_choices_method,
                                     help="Name of the struct to read")
-    read_struct_parser.add_argument('--data-without-names', '-d',
+    read_struct_parser.add_argument('--data_only', '-d',
                                     action="store_false",
                                     help="Show only the data without reg name")
+    read_struct_parser.add_argument('--compact', '-c',
+                                    action="store_false",
+                                    help="Output is compact")
     add_timeout_retry_arguments(read_struct_parser)
 
     @with_argparser(read_struct_parser)
     def do_read_struct(self, opts):
         """Read a set of registers defined by the memory map."""
         resp = self.dev_driver.read_struct(opts.struct,
+                                           data_has_name=opts.data_only,
                                            timeout=opts.timeout,
                                            retry=opts.retry)
-        self.poutput(pformat(resp, compact=True))
+        self.poutput(pformat(resp, compact=opts.compact))
 
     commit_parser = argparse.ArgumentParser()
     add_timeout_retry_arguments(commit_parser)
@@ -226,10 +221,9 @@ class MmCmd(Cmd):
             }
         """
         if opts.reg:
-            self.poutput(pformat(self.dev_driver.mem_map[opts.reg],
-                                 sort_dicts=True))
+            self.poutput(pformat(self.dev_driver.mem_map[opts.reg]))
         else:
-            self.poutput(pformat(self.dev_driver.mem_map, sort_dicts=True))
+            self.poutput(pformat(self.dev_driver.mem_map))
 
     info_param_parser = argparse.ArgumentParser()
     info_param_parser.add_argument('param',
@@ -243,7 +237,7 @@ class MmCmd(Cmd):
         for key, val in self.dev_driver.mem_map.items():
             if opts.param in val:
                 record_types[key] = val[opts.param]
-        self.poutput(pformat(record_types, sort_dicts=True))
+        self.poutput(pformat(record_types))
 
     # pylint: disable=unused-argument
     def _onchange_loglevel(self, param_name, old, new):

--- a/mock_pal/__init__.py
+++ b/mock_pal/__init__.py
@@ -11,9 +11,9 @@ from .mock_if import MockIf
 from .mock_dev import VirtualPortRunner, MockDev
 from .mock_cli import MockCli
 
+
 __author__ = "Kevin Weiss"
 __email__ = "kevin.weiss@gmail.com"
-__version__ = "1.1.2"
 
 __all__ = ['MockIf',
            'VirtualPortRunner',

--- a/mock_pal/mock_cli.py
+++ b/mock_pal/mock_cli.py
@@ -49,14 +49,16 @@ class MockCli(MmCmd):
         if 'dev_driver' in kwargs:
             super().__init__(kwargs['dev_driver'], **cmd_kwargs)
             return
-        port = kwargs.get('port', None)
+        if 'driver' in kwargs:
+            super().__init__(MockIf(driver=kwargs['driver']), **cmd_kwargs)
+            return
 
-        if port is None:
+        if "port" not in kwargs:
             super().__init__(serial_connect_wizard(MockIf, **kwargs),
                              **cmd_kwargs)
         else:
             super().__init__(MockIf(**kwargs), **cmd_kwargs)
-        self.logger.debug("__init__(%r)", kwargs)
+        self.logger.debug("__init__(%r, %r)", kwargs, cmd_kwargs)
 
     def do_special_cmd(self, arg):
         """Do nothing but show how to use special commands.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     url="https://github.com/riot-appstore",
     packages=find_packages(),
     platforms='any',
-    python_requires='>=3.8.*',
+    python_requires='>=3.6.*',
     include_package_data=True,
     classifiers=[
         "License :: OSI Approved :: MIT License",
@@ -48,6 +48,8 @@ setup(
         "Development Status :: 3 - Alpha",
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         "Intended Audience :: Developers"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from mock_pal import MockDev, VirtualPortRunner
 from mm_pal.serial_driver import SerialDriver
 from mm_pal import MmIf
 
-SLEEP_TIME = 0.1
+SLEEP_TIME = 0.2
 
 MM_PATH = str(Path(__file__).parents[0]) + \
           "/../mock_pal/mem_map/example_map_t_0_0_1.csv"

--- a/tests/test_serial_driver.py
+++ b/tests/test_serial_driver.py
@@ -83,9 +83,11 @@ def test_readline(mock_lb, ser_dri):
     ser_dri.writeline("foo")
     assert ser_dri.readline(timeout=1) == "foo\n"
 
-    ser_dri.writeline("foo")
     with pytest.raises(TimeoutError):
-        ser_dri.readline(timeout=0)
+        # Try it a few times in case the response is fast enough...
+        for _ in range(5):
+            ser_dri.writeline("foo")
+            ser_dri.readline(timeout=0)
 
 
 def test_readline_to_delim(mock_lb, ser_dri):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
-envlist = test,doctest,lint,flake8,py38,py39
+envlist = test,doctest,lint,flake8,py36,py37,py38,py39
 
 [gh-actions]
 python =
+    3.6: py36,test
+    3.7: py37,test
     3.8: py38,test
     3.9: py39,doctest,test,lint,flake8
 


### PR DESCRIPTION
- doc: Update readme with cmd2 info
- cleanup(mock_pal): Remove pointless version/port
- fix(mm_pal): Fix read_struct args
- bump: Verison 1.1.2 -> 1.1.3
- Add support for python3.6 and 3.7
- fix(tests): Occasional failure if too fast